### PR TITLE
Custom tokens

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   shortcut: 0
   system: 0
   taxonomy: 0
+  test_tokens: 0
   text: 0
   toolbar: 0
   update: 0

--- a/web/modules/custom/test_tokens/src/Enum/Versions.php
+++ b/web/modules/custom/test_tokens/src/Enum/Versions.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\test_tokens\Enum;
+
+use Drupal\Component\Datetime\DateTimePlus;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Existing project versions.
+ */
+enum Versions: string {
+
+  case First = 'v1';
+  case Second = 'v2';
+  case Third = 'v3';
+  case Fourth = 'v4';
+  case Fifth = 'v5';
+
+  /**
+   * Get the current version depending on the current date.
+   *
+   * @return self|null
+   *   The version.
+   */
+  public static function currentVersion(): ?self {
+    $current_month = DateTimePlus::createFromFormat('U', time())->format('Ymd');
+
+    foreach (self::cases() as $version) {
+      if ($version->begin() <= $current_month && ($version->end() === '' || $version->end() > $current_month)) {
+        $current_version = $version;
+      }
+    }
+
+    return $current_version;
+  }
+
+  /**
+   * Begin date.
+   *
+   * @return string
+   *   The first day of the version.
+   */
+  public function begin(): string {
+    return match ($this) {
+      self::First => '20240102',
+      self::Second => '20240709',
+      self::Third => '20250303',
+      self::Fourth => '20250901',
+      self::Fifth => '20260105',
+    };
+  }
+
+  /**
+   * End date.
+   *
+   * @return string
+   *   The last day of the version.
+   */
+  public function end(): string {
+    return match ($this) {
+      self::First => '20240708',
+      self::Second => '20250302',
+      self::Third => '20250831',
+      self::Fourth => '20250104',
+      self::Fifth => '',
+    };
+  }
+
+  /**
+   * Human-readable date from begin method.
+   *
+   * @return string
+   *   The date.
+   */
+  public function humanReadableBeginDate(): string {
+    return \Drupal::service('date.formatter')
+      ->format(
+        DateTimePlus::createFromFormat(
+          'Ymd',
+          $this->begin()
+        )->getTimestamp(),
+        'custom_long_day'
+      );
+  }
+
+  /**
+   * Human-readable date from begin method.
+   *
+   * @return string
+   *   The date.
+   */
+  public function humanReadableEndDate(): string {
+    return \Drupal::service('date.formatter')
+      ->format(
+        DateTimePlus::createFromFormat(
+          'Ymd',
+          $this->end()
+        )->getTimestamp(),
+        'custom_long_day'
+      );
+  }
+
+}

--- a/web/modules/custom/test_tokens/test_tokens.info.yml
+++ b/web/modules/custom/test_tokens/test_tokens.info.yml
@@ -1,0 +1,5 @@
+name: 'Test : Tokens'
+type: module
+description: 'Provides custom tokens.'
+core_version_requirement: ^11
+package: Custom

--- a/web/modules/custom/test_tokens/test_tokens.module
+++ b/web/modules/custom/test_tokens/test_tokens.module
@@ -1,0 +1,64 @@
+<?php
+
+// phpcs:ignoreFile
+
+use Drupal\test_tokens\Enum\Versions;
+
+function test_tokens_token_info() {
+  $types = [
+    'versions' => [
+      'name' => 'Tokens de version',
+      'description' => 'Défini des tokens custom pour les versions du projet.',
+    ],
+  ];
+
+  $tokens = [
+    'versions' => [
+      'current_version' => [
+        'name' => t('Current version'),
+        'description' => t('Current version.'),
+      ],
+      'start' => [
+        'name' => t('Start date'),
+        'description' => t('The first day of the current version.'),
+      ],
+      'end' => [
+        'name' => t('End date'),
+        'description' => t('The last day of the current version.'),
+      ],
+    ],
+  ];
+
+  return [
+    'types' => $types,
+    'tokens' => $tokens,
+  ];
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function test_tokens_tokens($type, $tokens, $data, $options, $bubbleable_metadata) {
+  $replacements = array();
+
+  if ($type == 'versions') {
+    $current_version = Versions::currentVersion();
+
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'current_version':
+          // @phpstan-ignore-next-line
+          $replacements[$original] = $current_version->value ?? t('unknown version');
+          break;
+        case 'start':
+          $replacements[$original] = $current_version->humanReadableBeginDate();
+          break;
+        case 'end':
+          $replacements[$original] = $current_version->humanReadableEndDate();
+          break;
+      }
+    }
+  }
+
+  return $replacements;
+}


### PR DESCRIPTION
### Contexte de la MR :

- Drupal 11.2
- PHP 8.4

Le projet contient plusieurs versions, versions définies en fonction des dates.

Le client souhaite bénéficier de 3 tokens utilisables dans ses vues :
- `current-version` qui afficherait la version courante
- `start` qui afficherait la date de début de la version
- `end` qui afficherait la date de fin de la version

Les dates doivent être affichées de cette façon : "Jeudi 31 juillet 2025". Il a été vu en affinage qu'il serait bien de créer un format de date custom.